### PR TITLE
Add quotes around variables passed to docker

### DIFF
--- a/code/6/tomcat/tprov/lib/tprov/app.rb
+++ b/code/6/tomcat/tprov/lib/tprov/app.rb
@@ -59,7 +59,7 @@ module TProv
 
     helpers do
       def get_war(name, url)
-        cid = `docker run --name #{name} jamtur01/fetcher #{url} 2>&1`.chop
+        cid = `docker run --name "#{name}" jamtur01/fetcher "#{url}" 2>&1`.chop
         puts cid
         [$?.exitstatus == 0, cid]
       end


### PR DESCRIPTION
Expanding the URL seems to cause Ruby 1.9.3 some serious confusion.
Adding double quotes around the vars resolves the problem.
