### PR TITLE
Add trailing / to volume to match book example

### DIFF
--- a/code/6/tomcat/fetcher/Dockerfile
+++ b/code/6/tomcat/fetcher/Dockerfile
@@ -5,7 +5,7 @@ ENV REFRESHED_AT 2014-06-01
 RUN apt-get -yqq update
 RUN apt-get -yqq install wget
 
-VOLUME [ "/var/lib/tomcat7/webapps" ]
+VOLUME [ "/var/lib/tomcat7/webapps/" ]
 WORKDIR /var/lib/tomcat7/webapps/
 
 ENTRYPOINT [ "wget" ]


### PR DESCRIPTION
The code block in the book has a trailing / on the VOLUME command. 

Additionally, with the `fetcher` Dockerfile using `"/var/lib/tomcat7/webapps"` and the `tomcat7` Dockerfile using `"/var/lib/tomcat7/webapps/"`, docker ends up interpreting them as different mounts and the example doesn't work.
