### PR TITLE
Remove /var/www/html volume creation

### DIFF
--- a/code/6/jekyll/apache/Dockerfile
+++ b/code/6/jekyll/apache/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER James Turnbull <james@example.com>
 RUN apt-get -yqq update
 RUN apt-get -yqq install apache2
 
-VOLUME [ "/var/www/html" ]
+
 WORKDIR /var/www/html
 
 ENV APACHE_RUN_USER www-data


### PR DESCRIPTION
Hello, James!
I'm sending this PR only to ask a question.
it's the same chapter of your book.
Now I've got a question about apache Dockerfile.
VOLUME /data directive.
Why did you add volume /var/www/html to apache?
Further in your book you TARing files from --volumes-from james_blog (jekyl image).
Why do we need volume in apache?

Could you please elaborate?