### PR TITLE
Create redis-cli image for testing redis install

### DIFF
--- a/code/5/sinatra/redis-cli/Dockerfile
+++ b/code/5/sinatra/redis-cli/Dockerfile
@@ -1,0 +1,9 @@
+FROM ubuntu:14.04
+MAINTAINER James Turnbull "james@example.com"
+ENV REFRESHED_AT 2015-07-20
+
+RUN apt-get update
+RUN apt-get -y install redis-tools
+
+ENTRYPOINT ["/usr/bin/redis-cli"]
+CMD []


### PR DESCRIPTION
Dear James,

I found this `Dockerfile` useful while following your examples in **The Docker Book**. I didn't want to install the redis-tools on the machine I was using, so I made a container to create a throwaway box that had `redis-cli` installed.

To run the container, I used `docker run -ti --rm --name="redis-cli" rac/redis-cli -h $DOCKER_IP -p $REDIS_PORT`. This seemed to successfully connected to my running redis container, but I was not able to type anything or get any output. If I run `docker attach redis-cli` from another terminal window, I am able to type in that terminal and get the expected results (i.e. an interactive `redis-cli` prompt). I'm chalking this up to my ignorance of docker and redis. As that diminishes, I may update this pull request with a more useful way to execute the `redis-cli` image. 

Thank you for writing such a useful book.

Sincerely,
Raúl