### PR TITLE
I couldn't get the tprov examples to work in boot2docker

### DIFF
--- a/code/8/tprov_api/lib/tprov/app.rb
+++ b/code/8/tprov_api/lib/tprov/app.rb
@@ -21,8 +21,15 @@ module TProv
     set :views, File.join(File.dirname(__FILE__), 'views')
     set :bind, '0.0.0.0'
 
+    ENV['DOCKER_CERT_PATH'] ||= '/certs'
+    cert_path = File.expand_path(ENV['DOCKER_CERT_PATH'])
+
     Docker.url = ENV['DOCKER_URL'] || 'https://localhost:2375'
     Docker.options = {
+      :client_cert => File.join(cert_path, 'cert.pem'),
+      :client_key => File.join(cert_path, 'key.pem'),
+      :ssl_ca_file => File.join(cert_path, 'ca.pem'),
+      :scheme => 'https',
       :ssl_verify_peer => false
     }
 

--- a/code/8/tprov_api/lib/tprov/app.rb
+++ b/code/8/tprov_api/lib/tprov/app.rb
@@ -72,7 +72,7 @@ module TProv
       end
 
       def create_instance(name)
-        container = Docker::Container.create('Image' => 'jamtur01/tomcat7', 'PublishAllPorts' => true, 'VolumesFrom' => name)
+        container = Docker::Container.create('Image' => 'jamtur01/tomcat7', 'PublishAllPorts' => true, 'VolumesFrom' => [name])
         container.start
         container.id
       end

--- a/code/8/tprov_api/lib/tprov/app.rb
+++ b/code/8/tprov_api/lib/tprov/app.rb
@@ -21,17 +21,10 @@ module TProv
     set :views, File.join(File.dirname(__FILE__), 'views')
     set :bind, '0.0.0.0'
 
-    ENV['DOCKER_CERT_PATH'] ||= '/certs'
-    cert_path = File.expand_path(ENV['DOCKER_CERT_PATH'])
-
-    Docker.url = ENV['DOCKER_URL'] || 'https://localhost:2375'
+    Docker.url = ENV['DOCKER_URL'] || 'unix:///var/run/docker.sock'
     Docker.options = {
-      :client_cert => File.join(cert_path, 'cert.pem'),
-      :client_key => File.join(cert_path, 'key.pem'),
-      :ssl_ca_file => File.join(cert_path, 'ca.pem'),
-      :scheme => 'https',
       :ssl_verify_peer => false
-    }
+    } unless Docker.url == 'unix:///var/run/docker.sock'
 
     enable :sessions, :logging, :dump_errors, :raise_errors, :show_exceptions
 

--- a/code/8/tprov_api/lib/tprov/app.rb
+++ b/code/8/tprov_api/lib/tprov/app.rb
@@ -72,8 +72,8 @@ module TProv
       end
 
       def create_instance(name)
-        container = Docker::Container.create('Image' => 'jamtur01/tomcat7')
-        container.start('PublishAllPorts' => true, 'VolumesFrom' => name)
+        container = Docker::Container.create('Image' => 'jamtur01/tomcat7', 'PublishAllPorts' => true, 'VolumesFrom' => name)
+        container.start
         container.id
       end
 


### PR DESCRIPTION
tprov tried to speak HTTPS to the docker daemon in my boot2docker VM but the port mismatched, which I had to figure out how to use by looking at the example code and setting DOCKER_URL.  Then I had issues with the boot2docker certs not matching the CA certificate, etc., and Sinatra spilled quite a few drinks.  Friggin' drunk.

Finally, I realized, "why not just NOT use SSL and mount /var/run/docker.sock as a volume," like @jpetazzo said in http://jpetazzo.github.io/2015/09/03/do-not-use-docker-in-docker-for-ci/, and I have this pull request.  Maybe it's not complete.

When I run the tprov container, the command is:

docker run -d -P -v /var/run/docker.sock:/var/run/docker.sock --privileged --name tprov gswallow/tprov

Finally, it appears that start and create are different in newer versions of the docker API.