### PR TITLE
Failure launch `docker build -t jamtur01/nodejs .`

### DIFF
--- a/code/6/node/nodejs/Dockerfile
+++ b/code/6/node/nodejs/Dockerfile
@@ -10,6 +10,8 @@ RUN mkdir -p /var/log/nodeapp
 ADD nodeapp /opt/nodeapp/
 
 WORKDIR /opt/nodeapp
+RUN npm install -g npm
+RUN npm install -g node-gyp
 RUN npm install
 
 VOLUME [ "/var/log/nodeapp" ]


### PR DESCRIPTION
Hello!
I get error when I trying to launch `docker build -t jamtur01/nodejs .`
Log - https://bpaste.net/show/ede2cd09fc8c

Installed out of the box:
node - v0.10.25
npm - 1.3.10

After npm update:
npm - 3.8.5

About node-gyp: without this package I got error - `gyp ERR! stack Error: `gyp` failed with exit code: 1` like this http://stackoverflow.com/questions/19972402/nodejs-npm-install-pg-failed